### PR TITLE
fix(index): Fix broken upsertFn for careful operations

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -125,9 +125,9 @@ class Fastly {
   upsertFn(createFn, updateFn, readFn) {
     if (readFn) {
       // careful
-      return (version, name, data) => readFn(version, name)
-        .then(() => updateFn(version, name, data))
-        .catch(() => createFn(version, data));
+      return (version, name, data) => readFn.apply(this, [version, name])
+        .then(() => updateFn.apply(this, [version, name, data]))
+        .catch(() => createFn.apply(this, [version, data]));
     }
     // stubborn
     return (version, name, data) => createFn.apply(this, [version, data])


### PR DESCRIPTION
The upsertFn function lost the `this` context for careful updates (check for existence first). This
change uses `apply` consistently and fixes the issue

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
