### PR TITLE
fix(fastly): Increase default timeout to 15 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ to update values, as it will work for existing and non-existing items.</p>
 **Kind**: global class  
 
 * [Fastly](#Fastly)
-    * [new Fastly(token, service_id)](#new_Fastly_new)
+    * [new Fastly(token, service_id, timeout)](#new_Fastly_new)
     * [.readLogsFn(service)](#Fastly+readLogsFn) ⇒ [<code>ListFunction</code>](#ListFunction)
     * [.readLogFn(service)](#Fastly+readLogFn) ⇒ [<code>ReadFunction</code>](#ReadFunction)
     * [.createLogFn(service)](#Fastly+createLogFn) ⇒ [<code>CreateFunction</code>](#CreateFunction)
@@ -304,14 +304,15 @@ to update values, as it will work for existing and non-existing items.</p>
 
 <a name="new_Fastly_new"></a>
 
-#### new Fastly(token, service_id)
+#### new Fastly(token, service_id, timeout)
 The constructor method for creating a fastly-promises instance.
 
 
-| Param | Type | Description |
-| --- | --- | --- |
-| token | <code>string</code> | The Fastly API token. |
-| service_id | <code>string</code> | The Fastly service ID. |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| token | <code>string</code> |  | The Fastly API token. |
+| service_id | <code>string</code> |  | The Fastly service ID. |
+| timeout | <code>number</code> | <code>15000</code> | HTTP timeout for requests to the Fastly API, default: 15 seconds. |
 
 <a name="Fastly+readLogsFn"></a>
 

--- a/src/index.js
+++ b/src/index.js
@@ -141,12 +141,13 @@ class Fastly {
    *
    * @param {string} token - The Fastly API token.
    * @param {string} service_id - The Fastly service ID.
+   * @param {number} timeout - HTTP timeout for requests to the Fastly API, default: 15 seconds.
    */
-  constructor(token, service_id) {
+  constructor(token, service_id, timeout = 15000) {
     this.service_id = service_id;
     this.request = axios.create({
       baseURL: config.mainEntryPoint,
-      timeout: 5000,
+      timeout,
       headers: { 'Fastly-Key': token },
     });
 


### PR DESCRIPTION
Some Fastly API operations are slow, this change increases the default timeout to 15 seconds

fixes #41

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
