### PR TITLE
Request monitor and guarded Transactions

### DIFF
--- a/README.md.hbs
+++ b/README.md.hbs
@@ -188,6 +188,23 @@ Each `fastly-native-promises` API method returns the following response object:
 }
 ```
 
+## Retrieving Request Statistics
+
+The `Fastly` instance has a `requestmonitor` property that can be used to retrieve request statistics:
+
+- `requestmonitor.count` for the total number of requests
+- `requestmonitor.remaining` for the number of requests remaining according to Fastly's API Rate limit for the hour or `undefined` (if no modifying requests have been made yet)
+- `requestmonitor.edgedurations` for an array of API processing durations (in milliseconds, measured from the edge)
+- `requestmonitor.durations` for an array of request durations (in milliseconds, measured from the client, i.e. including network latency)
+
+With `requestmonitor.stats` you can get all of that in one object, including minumum, maximum and mean durations for all requests.
+
+## Guarding against Rate Limits
+
+Using the `requestmonitor.remaining` property, you can make sure that you still have sufficient requests before you hit the rate limit. 
+
+When using the `instance.transact` method, you can furthermore provide a minimum for the neccessary available request limit, so that after the inital cloning of the version no additional requests will be made if the API rate limit will be exceeded. This allows you to fail fast in case of rate limit issues.
+
 ## High-Level Helpers
 
 While most functionality is a low-level wrapper of the Fastly, API, we provide a couple of higher-level helper functions in properties of the `Fastly` instance.

--- a/src/httpclient.js
+++ b/src/httpclient.js
@@ -156,4 +156,4 @@ function create({ baseURL, timeout, headers }) {
   return client;
 }
 
-module.exports = { create };
+module.exports = { create, FastlyError };

--- a/src/index.js
+++ b/src/index.js
@@ -153,6 +153,8 @@ class Fastly {
       headers: { 'Fastly-Key': token },
     });
 
+    this.requestmonitor = this.request.monitor;
+
     this.versions = {
       current: undefined,
       active: undefined,

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,10 @@ const config = require('./config');
 const Conditions = require('./conditions');
 const Headers = require('./headers');
 
+class RateLimitError extends Error {
+
+}
+
 class Fastly {
   /**
    * @typedef {Function} CreateFunction
@@ -1337,6 +1341,11 @@ class Fastly {
    * optionally activates the newly created version. This function
    * is useful for making modifications to a service config.
    *
+   * You can provide a `limit` of write operations, which is an estimate
+   * of the number of write operations that will be attempted. If the
+   * limit is higher than the number of actions allowed by Fastly's rate
+   * limits, the function will fail fast after cloning the service config.
+   *
    * @example
    * ```javascript
    * await fastly.transact(async (newversion) => {
@@ -1346,10 +1355,14 @@ class Fastly {
    * ```
    * @param {Function} operations - A function that performs changes on the service config.
    * @param {boolean} activate - Set to false to prevent automatic activation.
+   * @param {number} limit - Number of write operations that will be performed in this action.
    * @returns {Object} The return value of the wrapped function.
    */
-  async transact(operations, activate = true) {
+  async transact(operations, activate = true, limit = 0) {
     const newversion = (await this.cloneVersion()).data.number;
+    if (limit > 0 && this.requestmonitor.remaining && this.requestmonitor.remaining < limit) {
+      throw new RateLimitError(`Insufficient number of requests (${this.requestmonitor.remaining}) remaining for number of scheduled operations (${limit})`);
+    }
     const result = await operations.apply(this, [newversion]);
     if (activate) {
       await this.activateVersion(newversion);

--- a/test/edgedict.integration.test.js
+++ b/test/edgedict.integration.test.js
@@ -3,6 +3,7 @@
 const { condit } = require('@adobe/helix-testutils');
 const nock = require('nock');
 const assert = require('assert');
+const expect = require('expect');
 const { AssertionError } = require('assert');
 const f = require('../src/index');
 
@@ -19,7 +20,14 @@ describe('#integration edge dictionary updates', () => {
     nock.activate();
   });
 
-  condit('Create Edge Dictionary', condit.hasenvs(['FASTLY_AUTH', 'FASTLY_SERVICE_ID']), async () => {
+  afterEach(() => {
+    Object.values(fastly.requestmonitor.stats).forEach((val) => {
+      // all stats should be numbers
+      expect(val).toBeGreaterThan(0);
+    });
+  });
+
+  condit('Create Edge Dictionary 1', condit.hasenvs(['FASTLY_AUTH', 'FASTLY_SERVICE_ID']), async () => {
     await fastly.transact(async (version) => {
       await fastly.writeDictionary(version, 'test_dict', {
         name: 'test_dict',

--- a/test/edgedict.integration.test.js
+++ b/test/edgedict.integration.test.js
@@ -27,7 +27,11 @@ describe('#integration edge dictionary updates', () => {
     });
   });
 
-  condit('Create Edge Dictionary 1', condit.hasenvs(['FASTLY_AUTH', 'FASTLY_SERVICE_ID']), async () => {
+  condit('Do not create Edge Dictionary due to insufficient limits', condit.hasenvs(['FASTLY_AUTH', 'FASTLY_SERVICE_ID']), async () => {
+    await expect(fastly.transact(() => {}, false, 2000)).rejects.toThrow();
+  }).timeout(5000);
+
+  condit('Create Edge Dictionary', condit.hasenvs(['FASTLY_AUTH', 'FASTLY_SERVICE_ID']), async () => {
     await fastly.transact(async (version) => {
       await fastly.writeDictionary(version, 'test_dict', {
         name: 'test_dict',


### PR DESCRIPTION
Fix for #30 

- monitor the number (and duration) of requests made
- monitor the remaining rate limit
- allow `transact` to fail fast if rate limit will be reached by a transaction