### PR TITLE
Make clone more robust

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -516,7 +516,7 @@ class Fastly {
    * @returns {Promise} The response object representing the completion or failure.
    */
   async cloneVersion(version) {
-    const versions = await this.request.put(`/service/${this.service_id}/version/${await this.getVersion(version, 'active')}/clone`);
+    const versions = await this.request.put(`/service/${this.service_id}/version/${await this.getVersion(version, 'active', 'current', 'latest', 'initial')}/clone`);
     this.versions.current = versions.data.number;
     this.versions.latest = versions.data.number;
     return versions;

--- a/src/index.js
+++ b/src/index.js
@@ -476,6 +476,7 @@ class Fastly {
       return this.versions;
     }
     const { data } = await this.readVersions();
+    this.versions.initial = 1;
     this.versions.latest = data
       .map(({ number }) => number)
       .pop();
@@ -491,12 +492,12 @@ class Fastly {
     return this.versions;
   }
 
-  async getVersion(version, fallbackname) {
+  async getVersion(version, ...fallbackname) {
     if (version) {
       return version;
     }
     const versions = await this.getVersions();
-    return versions[fallbackname];
+    return fallbackname.map((attempt) => versions[attempt]).filter((e) => e)[0];
   }
 
   /**

--- a/test/getVersions.initial.js
+++ b/test/getVersions.initial.js
@@ -1,0 +1,66 @@
+'use strict';
+
+/* eslint-env mocha */
+
+const nock = require('nock');
+const expect = require('expect');
+const config = require('../src/config');
+const fastlyPromises = require('../src/index');
+const response = require('./response/readVersions.initial.response');
+
+describe('#getVersions(inital)', () => {
+  const fastly = fastlyPromises('923b6bd5266a7f932e41962755bd4254', 'SU1Z0isxPaozGVKXdv0eY');
+  let versions;
+
+  const scope = nock(config.mainEntryPoint)
+    .get('/service/SU1Z0isxPaozGVKXdv0eY/version')
+    .reply(200, response.readVersions);
+
+  beforeEach(async () => {
+    versions = await fastly.getVersions();
+  });
+
+  it('active version should be undefined', () => {
+    expect(versions.active).toBeUndefined();
+  });
+
+  it('latest version should be 1', () => {
+    expect(versions.latest).toBe(1);
+  });
+
+  it('current version should be undefined', () => {
+    expect(versions.current).toBeUndefined();
+  });
+
+  after('API has been called once', () => {
+    scope.done();
+  });
+});
+
+describe('#getVersion(initial)', () => {
+  const fastly = fastlyPromises('923b6bd5266a7f932e41962755bd4254', 'SU1Z0isxPaozGVKXdv0eY');
+
+  const scope = nock(config.mainEntryPoint)
+    .get('/service/SU1Z0isxPaozGVKXdv0eY/version')
+    .reply(200, response.readVersions);
+
+  it('active version should be undefined', async () => {
+    expect(await fastly.getVersion(undefined, 'active')).toBeUndefined();
+  });
+
+  it('latest version should be 1', async () => {
+    expect(await fastly.getVersion(undefined, 'latest')).toBe(1);
+  });
+
+  it('current version should be undefined', async () => {
+    expect(await fastly.getVersion(undefined, 'current')).toBeUndefined();
+  });
+
+  it('current version should be 1 after fallbacks', async () => {
+    expect(await fastly.getVersion(undefined, 'nonsense', 'active', 'current', 'initial')).toBe(1);
+  });
+
+  after('API has been called once', () => {
+    scope.done();
+  });
+});

--- a/test/getVersions.test.js
+++ b/test/getVersions.test.js
@@ -36,3 +36,35 @@ describe('#getVersions', () => {
     scope.done();
   });
 });
+
+describe('#getVersion', () => {
+  const fastly = fastlyPromises('923b6bd5266a7f932e41962755bd4254', 'SU1Z0isxPaozGVKXdv0eY');
+
+  const scope = nock(config.mainEntryPoint)
+    .get('/service/SU1Z0isxPaozGVKXdv0eY/version')
+    .reply(200, response.readVersions);
+
+  it('active version should be undefined', async () => {
+    expect(await fastly.getVersion(undefined, 'active')).toBe(1);
+  });
+
+  it('latest version should be 2', async () => {
+    expect(await fastly.getVersion(undefined, 'latest')).toBe(2);
+  });
+
+  it('current version should be 2', async () => {
+    expect(await fastly.getVersion(undefined, 'current')).toBe(2);
+  });
+
+  it('current version should be 2 after fallbacks', async () => {
+    expect(await fastly.getVersion(undefined, 'nonsense', 'unknown', 'current', 'initial')).toBe(2);
+  });
+
+  it('initial version should be 1 after fallbacks', async () => {
+    expect(await fastly.getVersion(undefined, 'nonsense', 'initial', 'current', 'initial')).toBe(1);
+  });
+
+  after('API has been called once', () => {
+    scope.done();
+  });
+});

--- a/test/response/readVersions.initial.response.js
+++ b/test/response/readVersions.initial.response.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports.readVersions = [
+  {
+    active: false,
+    comment: '',
+    created_at: '2016-05-01T19:40:49+00:00',
+    deleted_at: null,
+    deployed: null,
+    locked: true,
+    number: 1,
+    service_id: 'SU1Z0isxPaozGVKXdv0eY',
+    staging: null,
+    testing: null,
+    updated_at: '2016-05-09T16:19:09+00:00',
+  },
+];


### PR DESCRIPTION
When there is no `active` version to clone, fall back to the `current`, `latest`, or `initial` version, so that there will never be an attempt to clone the version `undefined`.

This fixes #106 