### PR TITLE
perf: remove serialization of API calls

### DIFF
--- a/src/httpclient.js
+++ b/src/httpclient.js
@@ -169,8 +169,9 @@ function create({ baseURL, timeout, headers }) {
    * @param {Function} fn - The function to guard.
    * @returns {Function} A guarded function.
    */
-  function protect(fn) {
-    return async function protected(...args) {
+  /* istanbul ignore next */
+  function protect(fn) { // eslint-disable-line no-unused-vars
+    return async (...args) => {
       await lock.acquire();
       try {
         return fn(...args);
@@ -181,11 +182,17 @@ function create({ baseURL, timeout, headers }) {
   }
 
   const client = {
-    post: protect(makereq('post')),
+    // remove serialization of API calls: too broad in scope
+
+    // post: protect(makereq('post')),
+    post: makereq('post'),
     get: makereq('get', true, 2),
-    put: protect(makereq('put')),
-    patch: protect(makereq('patch')),
-    delete: protect(makereq('delete')),
+    // put: protect(makereq('put')),
+    put: makereq('put'),
+    // patch: protect(makereq('patch')),
+    patch: makereq('patch'),
+    // delete: protect(makereq('delete')),
+    delete: makereq('delete'),
     monitor: {
       get count() {
         return responselog.length;


### PR DESCRIPTION
The serialisation of API calls introduced in #242 is IMO too broad in scope and comes with a massive performance hit. 

The only issue we've experienced so far with parallel execution of API calls is about concurrently writing different custom vcl scripts and setting one of them as `main` script. This can lead to race conditions where a random script ends up being the `main` script. This issue has been fixed in client code: adobe/helix-publish/issues/549 and adobe/helix-publish/issues/550.

I've intentionally left the lock code in place so we can easily go back to full serialisation of API calls should we indeed encounter concurrency issues. 